### PR TITLE
Grids

### DIFF
--- a/__tests__/lib/components/Grid-test.js
+++ b/__tests__/lib/components/Grid-test.js
@@ -1,0 +1,92 @@
+jest.unmock('../../../lib/components/Grid.jsx');
+
+import React from 'react';
+// import TestUtils from 'react-addons-test-utils';
+import { mount } from 'enzyme';
+
+import { Grid, Col } from '../../../lib/components/Grid.jsx';
+
+describe('Grid', () => {
+
+  let wrapper = null;
+
+  it('is defined', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/2"></Col>
+        <Col width="6"></Col>
+      </Grid>
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it('has the usa-grid class', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/2"></Col>
+        <Col width="6"></Col>
+      </Grid>
+    );
+    expect(wrapper.hasClass('usa-grid')).toBe(true);
+  });
+  
+  it('has the usa-grid-full class', () => {
+    wrapper = mount(
+      <Grid full>
+        <Col width="1/2"></Col>
+        <Col width="6"></Col>
+      </Grid>
+    );
+    expect(wrapper.hasClass('usa-grid-full')).toBe(true);
+  });
+  
+  it('sets width to one-half', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/2"></Col>
+        <Col width="6"></Col>
+      </Grid>
+    );
+    expect(wrapper.find('.usa-width-one-half').length).toBe(2);
+  });
+  
+  it('sets width to one-third', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/3"></Col>
+        <Col width="4"></Col>
+      </Grid>
+    );
+    expect(wrapper.find('.usa-width-one-third').length).toBe(2);
+  });
+  
+  it('sets width to one-fourth', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/4"></Col>
+        <Col width="3"></Col>
+      </Grid>
+    );
+    expect(wrapper.find('.usa-width-one-fourth').length).toBe(2);
+  });
+  
+  it('sets width to one-sixth', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/6"></Col>
+        <Col width="2"></Col>
+      </Grid>
+    );
+    expect(wrapper.find('.usa-width-one-sixth').length).toBe(2);
+  });
+  
+  it('sets width to one-twelfth', () => {
+    wrapper = mount(
+      <Grid>
+        <Col width="1/12"></Col>
+        <Col width="1"></Col>
+      </Grid>
+    );
+    expect(wrapper.find('.usa-width-one-twelfth').length).toBe(2);
+  });
+});

--- a/lib/components/Grid.jsx
+++ b/lib/components/Grid.jsx
@@ -1,0 +1,118 @@
+import React, { PropTypes } from 'react';
+
+/**
+ * Column container aka row.
+ * You should put columns inside a Row
+ * @param {[bool]} full defaults to false -- if true, removes padding
+ * @param {[node]} children Children
+ * @returns {[node]} the rendered DOM node
+ */
+export function Row ({full, children}) {
+  return (
+    <div className={full ? 'usa-grid-full' : 'usa-grid'}>
+      {children}
+    </div>
+  );
+}
+
+Row.propTypes = {
+  full: PropTypes.bool,
+  children: PropTypes.node.isRequired
+};
+
+Row.defaultProps = {
+  full: false
+};
+
+/**
+ * Column that goes in a row that makes a grid
+ * @param {[string]} width width of the column
+ * @param {[node]} children Children
+ * @returns {[node]} the rendered DOM node
+ */
+export function Col({width, children}) {
+  let widthClass = 'usa-width-';
+  
+  switch(width) {
+  case '1/1':
+  case '12':
+    widthClass += 'one-whole';
+    break;
+  case '1/2':
+  case '6':
+    widthClass += 'one-half';
+    break;
+  case '1/3':
+  case '4':
+    widthClass += 'one-third';
+    break;
+  case '2/3':
+  case '8':
+    widthClass += 'two-thirds';
+    break;
+  case '1/4':
+  case '3':
+    widthClass += 'one-fourth';
+    break;
+  case '3/4':
+  case '9':
+    widthClass += 'three-fourths';
+    break;
+  case '1/6':
+  case '2':
+    widthClass += 'one-sixth';
+    break;
+  case '5/6':
+  case '10':
+    widthClass += 'five-sixths';
+    break;
+  case '1/12':
+  case '1':
+    widthClass += 'one-twelfth';
+    break;
+  case '5/12':
+  case '5':
+    widthClass += 'five-twelfths';
+    break;
+  case '7/12':
+  case '7':
+    widthClass += 'seven-twelfths';
+    break;
+  default:
+    widthClass += 'one-whole';
+  }
+  
+  return (
+    <div className={widthClass}>
+      {children}
+    </div>
+  );
+}
+
+Col.propTypes = {
+  width: PropTypes.oneOf([
+    '1/1',
+    '1/2',
+    '1/3',
+    '2/3',
+    '1/4',
+    '3/4',
+    '1/6',
+    '5/6',
+    '1/12',
+    '5/12',
+    '7/12',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '10',
+    '12'
+  ]).isRequired,
+  children: PropTypes.node
+};

--- a/lib/components/Grid.jsx
+++ b/lib/components/Grid.jsx
@@ -1,13 +1,13 @@
 import React, { PropTypes } from 'react';
 
 /**
- * Column container aka row.
- * You should put columns inside a Row
+ * Column container aka Grid.
+ * You should put columns inside a Grid
  * @param {[bool]} full defaults to false -- if true, removes padding
  * @param {[node]} children Children
  * @returns {[node]} the rendered DOM node
  */
-export function Row ({full, children}) {
+export function Grid ({full, children}) {
   return (
     <div className={full ? 'usa-grid-full' : 'usa-grid'}>
       {children}
@@ -15,17 +15,17 @@ export function Row ({full, children}) {
   );
 }
 
-Row.propTypes = {
+Grid.propTypes = {
   full: PropTypes.bool,
   children: PropTypes.node.isRequired
 };
 
-Row.defaultProps = {
+Grid.defaultProps = {
   full: false
 };
 
 /**
- * Column that goes in a row that makes a grid
+ * Column that goes in a Grid that makes a grid
  * @param {[string]} width width of the column
  * @param {[node]} children Children
  * @returns {[node]} the rendered DOM node

--- a/styleguide/containers/GridContainer.jsx
+++ b/styleguide/containers/GridContainer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { Row, Col } from '../../lib/components/Grid';
 import BaseContainer from "./BaseContainer";
 
 /**
@@ -11,11 +11,146 @@ export default class GridContainer extends React.Component
    * Renders the node
    * @returns {node} the rendered DOM node
    */
-  render()
-  {
+  render() {
     return (
       <BaseContainer {...this.props}>
-        TODO
+        <h2 className="usa-heading">Grid expressed in fractions</h2>
+        <div className="preview preview-no_border grid-example grid-example-blank grid-text">
+          <Row>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+            <Col width="1/12">1/12</Col>
+          </Row>
+          <Row>
+            <Col width="1/1">1/1</Col>
+          </Row>
+          <Row>
+            <Col width="1/2">1/2</Col>
+            <Col width="1/2">1/2</Col>
+          </Row>
+          <Row>
+            <Col width="5/12">5/12</Col>
+            <Col width="7/12">7/12</Col>
+          </Row>
+          <Row>
+            <Col width="1/3">1/3</Col>
+            <Col width="2/3">2/3</Col>
+          </Row>
+          <Row>
+            <Col width="1/4">1/4</Col>
+            <Col width="3/4">3/4</Col>
+          </Row>
+          <Row>
+            <Col width="1/6">1/6</Col>
+            <Col width="5/6">5/6</Col>
+          </Row>
+          <Row>
+            <Col width="1/12">1/12</Col>
+            <Col width="5/12">5/12</Col>
+            <Col width="1/2">1/2</Col>
+          </Row>
+        </div>
+        <h2 className="usa-heading">Grid expressed in columns</h2>
+        <div className="preview preview-no_border grid-example grid-example-blank grid-text">
+          <Row>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+            <Col width="1">1</Col>
+          </Row>
+          <Row>
+            <Col width="12">12</Col>
+          </Row>
+          <Row>
+            <Col width="6">6</Col>
+            <Col width="6">6</Col>
+          </Row>
+          <Row>
+            <Col width="5">5</Col>
+            <Col width="7">7</Col>
+          </Row>
+          <Row>
+            <Col width="4">4</Col>
+            <Col width="8">8</Col>
+          </Row>
+          <Row>
+            <Col width="3">3</Col>
+            <Col width="9">9</Col>
+          </Row>
+          <Row>
+            <Col width="2">2</Col>
+            <Col width="10">10</Col>
+          </Row>
+          <Row>
+            <Col width="1">1</Col>
+            <Col width="5">5</Col>
+            <Col width="6">6</Col>
+          </Row>
+        </div>
+        
+        <div>
+          <h5>Example usage</h5>
+          <pre><code>
+            {`import { Row, Col } from 'pathto../lib/Grid'
+
+<Row>
+  <Col width="1/2">Half of twelve columns ...</Col>
+  <Col width="6">... is the same as 6 columns</Col>
+</Row>`}
+          </code></pre>
+          
+          <h4>Row</h4>
+          <h5>Optional props</h5>
+          <ul>
+            <li>
+              <code>full</code> <em>bool, defaults to false</em> — If true, removes the container's left and right padding.
+            </li>
+          </ul>
+          
+          <h4>Col</h4>
+          <h5>Required props</h5>
+          <ul>
+            <li><code>width</code> <em>string</em> — the fraction of the container width or the number of columns desired (out of 12). Must be one of '1/1',
+            '1/2',
+            '1/3',
+            '2/3',
+            '1/4',
+            '3/4',
+            '1/6',
+            '5/6',
+            '1/12',
+            '5/12',
+            '7/12',
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            '10',
+            '12'</li>
+          </ul>
+        </div>
       </BaseContainer>
     );
   }

--- a/styleguide/containers/GridContainer.jsx
+++ b/styleguide/containers/GridContainer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Row, Col } from '../../lib/components/Grid';
+import { Grid, Col } from '../../lib/components/Grid';
 import BaseContainer from "./BaseContainer";
 
 /**
@@ -16,7 +16,7 @@ export default class GridContainer extends React.Component
       <BaseContainer {...this.props}>
         <h2 className="usa-heading">Grid expressed in fractions</h2>
         <div className="preview preview-no_border grid-example grid-example-blank grid-text">
-          <Row>
+          <Grid>
             <Col width="1/12">1/12</Col>
             <Col width="1/12">1/12</Col>
             <Col width="1/12">1/12</Col>
@@ -29,39 +29,39 @@ export default class GridContainer extends React.Component
             <Col width="1/12">1/12</Col>
             <Col width="1/12">1/12</Col>
             <Col width="1/12">1/12</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/1">1/1</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/2">1/2</Col>
             <Col width="1/2">1/2</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="5/12">5/12</Col>
             <Col width="7/12">7/12</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/3">1/3</Col>
             <Col width="2/3">2/3</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/4">1/4</Col>
             <Col width="3/4">3/4</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/6">1/6</Col>
             <Col width="5/6">5/6</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1/12">1/12</Col>
             <Col width="5/12">5/12</Col>
             <Col width="1/2">1/2</Col>
-          </Row>
+          </Grid>
         </div>
         <h2 className="usa-heading">Grid expressed in columns</h2>
         <div className="preview preview-no_border grid-example grid-example-blank grid-text">
-          <Row>
+          <Grid>
             <Col width="1">1</Col>
             <Col width="1">1</Col>
             <Col width="1">1</Col>
@@ -74,49 +74,49 @@ export default class GridContainer extends React.Component
             <Col width="1">1</Col>
             <Col width="1">1</Col>
             <Col width="1">1</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="12">12</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="6">6</Col>
             <Col width="6">6</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="5">5</Col>
             <Col width="7">7</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="4">4</Col>
             <Col width="8">8</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="3">3</Col>
             <Col width="9">9</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="2">2</Col>
             <Col width="10">10</Col>
-          </Row>
-          <Row>
+          </Grid>
+          <Grid>
             <Col width="1">1</Col>
             <Col width="5">5</Col>
             <Col width="6">6</Col>
-          </Row>
+          </Grid>
         </div>
         
         <div>
           <h5>Example usage</h5>
           <pre><code>
-            {`import { Row, Col } from 'pathto../lib/Grid'
+            {`import { Grid, Col } from 'pathto../lib/Grid'
 
-<Row>
+<Grid>
   <Col width="1/2">Half of twelve columns ...</Col>
   <Col width="6">... is the same as 6 columns</Col>
-</Row>`}
+</Grid>`}
           </code></pre>
           
-          <h4>Row</h4>
+          <h4>Grid</h4>
           <h5>Optional props</h5>
           <ul>
             <li>


### PR DESCRIPTION
Makes 18F's existing grid styling into two components: Grid and Col. Adds no additional features or fixes 18F's bugs relating to using certain widths, such as 3/4 and 5/12. 

Proposing we leave this grid system as-is, but recognizing that's it's bad, implement another grid system with a different naming convention. Perhaps using Bootstrap 4's flexbox grid or http://flexboxgrid.com and calling the group of new components FlexGrid or Layout or something.